### PR TITLE
Fix small bug in BaseCommands example

### DIFF
--- a/plugins/BaseCommands.py
+++ b/plugins/BaseCommands.py
@@ -32,7 +32,7 @@ class BaseCommandsPlugin:
 		self.net.push_packet('PLAY>Chat Message', {'message': 'Current Date: ' + str(datetime.datetime.now())})
 
 	def handle_command(self, event, data):
-		self.net.push_packet('PLAY>Chat Message', {'message': '/' + ' '.join(args)})
+		self.net.push_packet('PLAY>Chat Message', {'message': '/' + ' '.join(data['args'])})
 
 	def handle_slot(self, event, data):
 		args = data['args']


### PR DESCRIPTION
in handle_command it referenced 'args' rather than data['args'] leading to: NameError: global name 'args' is not defined
