### PR TITLE
Fix chat_command plugin for modded servers

### DIFF
--- a/plugins/chat_command.py
+++ b/plugins/chat_command.py
@@ -26,7 +26,7 @@ class ChatCommandPlugin(PluginBase):
         self.prefix = self.settings['prefix']
 
     def handle_chat_message(self, event, data):
-        message = data['message']
+        message = data['message'] or data['text']
         try:
             command = message[message.index(self.prefix):]
             args = []


### PR DESCRIPTION
`message` doesn't get set on some modded servers, so fallback to full chat `text` in that case.
